### PR TITLE
New modes for runlists

### DIFF
--- a/foremanTool.py
+++ b/foremanTool.py
@@ -581,8 +581,18 @@ class ForemanTool(LoggingApp):
             elif method == "update":
                 self.params.extra = element
                 self.log.error(self.update(conn))
+            elif method == "update-create":
+                self.params.extra = element
+                i = self.index_instances(conn)
+                if len(i) == 0:
+                    self.log.debug("Could not find what you wanted to update, creating...")
+                    self.log.error(self.create(conn,element))
+                else:
+                    self.log.error(self.update(conn))
             elif method == "delete":
                 self.log.error(self.delete_instances(conn))
+            elif method == "none":
+                continue
             else:
                 self.log.error("Method " + method + " has not been created yet!")
                 continue

--- a/foremanTool.py
+++ b/foremanTool.py
@@ -89,8 +89,14 @@ class ForemanTool(LoggingApp):
                     self.log.warn("Not operating on " + key + " " + str(host_id) + " - " + host[key]['name'] )
                     continue
             else:
-                conn.destroy(host_id)
-
+                try:
+                    if func == "Host":
+                        conn.destroy_hosts(host_id)
+                    if func == "HostGroup":
+                        conn.destroy_hostgroups(hosts_id)
+                except Exception as e:
+                    self.log.error(e)
+                    quit('There was an error trying to delete ' + key + str(host_id) + " - " + host[key]['name'])
     def destroy(self,conn,i):
         func = self.params.function
         if func == "Architecture":

--- a/templates/ec2.json
+++ b/templates/ec2.json
@@ -23,7 +23,6 @@
     "puppet_status": 1,
     "build": "1",
     "type": "Host::Managed",
-    "mac": "flavor",
     "medium_id": "@medium_id@",
     "enabled": "1",
     "hostgroup_id": "@hostgroup_id@",


### PR DESCRIPTION
Hey!

I have changed a few things in the code, fixing some minor bugs and introducing several new modes for deploying runlists. In the past version, only supported methods were create, update and delete. When you have a complete stack and only want to update one item I don't want to create another runlist, so I added the method "none" (so no action is taken in the element) and "create-once" (create the element and don't do anything if the element has been created earlier) and "update-create" (try to update an element and, if not exists, creates it). I hope this would be helpful for you.

Moreover, now it is possible to auto-delete host and hostgroups from runlists with -A flag, and I changed the mac field in the ec2.json template, as it is not used.

Feel free to merge or change something the way you prefer.

Regards! :)